### PR TITLE
Use vendored docopt/raw_to_text

### DIFF
--- a/src/logtool/log.py
+++ b/src/logtool/log.py
@@ -95,7 +95,7 @@ import sys
 import os
 from dataclasses import dataclass
 
-from docopt import docopt
+from .vendor.docopt import docopt
 
 # NOTE:  CYGWIN primary broken /bin/script in a recent (late '18) release of
 #        util-linux removed it (albiet temporarily).  I had to track down an
@@ -103,7 +103,7 @@ from docopt import docopt
 
 from plumbum import RETCODE
 from plumbum.commands.processes import ProcessExecutionError
-from plumbum.cmd import raw_to_text
+from .vendor.raw_to_text import raw_to_text
 
 from logtool import __version__
 
@@ -195,14 +195,15 @@ def perform(cfg):
             print('log:  retcode = {}'.format(str(retcode)))
         if not cfg.raw :
             if cfg.verbose:
-                print('-- converting raw output to text using raw-to-text')
+                print('-- converting raw output to text using raw_to_text')
             raw_file = cfg.logfile + '.raw'
             txt_file = cfg.logfile + '.txt'
-            convert_retcode = ( ( raw_to_text['-'] < cfg.logfile ) > txt_file ) & RETCODE(FG=True)
-            if convert_retcode == 0:
+            try:
+                with open(cfg.logfile, 'r') as in_f, open(txt_file, 'w') as out_f:
+                    raw_to_text(in_f, out_f)
                 os.rename(cfg.logfile, raw_file)
                 os.rename(txt_file, cfg.logfile)
-            else :
+            except Exception:
                 print("*** raw to text conversion failed, raw logfile unchanged.")
         return retcode
 

--- a/src/logtool/logts.py
+++ b/src/logtool/logts.py
@@ -88,7 +88,7 @@ from pprint import PrettyPrinter
 pp = PrettyPrinter(indent=4).pprint
 pp8 = PrettyPrinter(indent=8).pprint
 
-from docopt import docopt
+from .vendor.docopt import docopt
 
 from logtool import __version__, log
 

--- a/src/logtool/pscript.py
+++ b/src/logtool/pscript.py
@@ -31,7 +31,7 @@ import time
 
 import shlex
 
-from docopt import docopt
+from .vendor.docopt import docopt
 
 from plumbum import local
 from plumbum.commands.processes import ProcessExecutionError


### PR DESCRIPTION
## Summary
- use vendored docopt instead of external one
- rely on internal raw_to_text implementation in `log` module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'prettyprinter')*

------
https://chatgpt.com/codex/tasks/task_b_684bd32792e0832689b4ff96278f970e